### PR TITLE
correct Python pinning in environment.yml and pyproject.toml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - python >=3.10
+  - python >=3.11
   - pip !=21.3
   - bitmath
   - cf-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ description = "Lightweight tool for investigating data files in an s3 repository
 license = "BSD-3-Clause"
 license-files = ["LICENSE.txt"]
 name = "cfs3"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.scripts]
 s3view = "cfs3.s3view:main"


### PR DESCRIPTION
We can't support Python 3.10 due to dependency on `cf-python`, and the conda package is also built with `python_min = 3.11`.